### PR TITLE
Remove pip cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - "3.6"
 # command to install dependencies
 install:
+  - pip install pipenv --upgrade
   - pipenv install --dev
 # command to run tests
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ python:
   - "3.6"
 # command to install dependencies
 install:
-  - pip install pipenv
   - pipenv install --dev
 # command to run tests
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,9 @@ sudo: false
 language: python
 python:
   - "3.6"
-cache: pip
+cache:
+  directories:
+    - $HOME/.cache
 # command to install dependencies
 install:
   - pip install pipenv --upgrade

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,9 @@ sudo: false
 language: python
 python:
   - "3.6"
-cache:
-  directories:
-    - $HOME/.cache
 # command to install dependencies
 install:
-  - pip install pipenv --upgrade
+  - pip install pipenv
   - pipenv install --dev
 # command to run tests
 script:


### PR DESCRIPTION
Produces more overhead to install the caching tools than actually installing the requirements takes time

Maybe introduce it again if the list of requirements gets larger